### PR TITLE
fix: 修复unittest_args参数未设置默认值而导致的参数检查错误

### DIFF
--- a/kea2/kea_launcher.py
+++ b/kea2/kea_launcher.py
@@ -189,12 +189,13 @@ def _sanitize_args(args):
             args.driver_name = "d"
         else:
             raise ValueError("--driver-name should be specified when customizing script in --agent u2")
+    setattr(args, "unittest_args", []) #Assign the default value prior to other assignments.
     if args.extra:
         args.extra = args.extra[1:] if args.extra[0] == "--" else args.extra
         unittest_index = args.extra.index("unittest") if "unittest" in args.extra else -1
         if unittest_index != -1:
             unittest_args = args.extra[unittest_index+1:]
-            setattr(args, "unittest_args", unittest_args)
+            args.unittest_args = unittest_args
             args.extra = args.extra[:unittest_index]
 
 def run(args=None):


### PR DESCRIPTION
在针对**issue#85**进行溯源时，我发现原因在于kea_launcher.py中的_sanitize_args函数对unittest_args赋值时跳过了用户指令中不存在unittest_args参数的情况，则在这种情况下args就不存在"unittest_args"这一参数，从而导致了issue#85中提到的参数校验失败的结果。 综合代码上下文，为了不影响后续代码实现，需要提前赋上默认值来覆盖到此情况，将unittest_args默认值设置为空列表，纵使用户未输入该参数，也不会影响unittest.main()的参数检查和其他任何影响。
<img width="1267" height="417" alt="image" src="https://github.com/user-attachments/assets/d073565e-8f3f-471d-a432-21ae6764806d" />

